### PR TITLE
add an extra format token to the primary data string so that JRuby do…

### DIFF
--- a/lib/active_model_serializers/json_pointer.rb
+++ b/lib/active_model_serializers/json_pointer.rb
@@ -4,7 +4,7 @@ module ActiveModelSerializers
 
     POINTERS = {
       attribute:    '/data/attributes/%s'.freeze,
-      primary_data: '/data'.freeze
+      primary_data: '/data%s'.freeze
     }.freeze
 
     def new(pointer_type, value = nil)


### PR DESCRIPTION
…esn't break

for: https://github.com/rails-api/active_model_serializers/pull/1004
